### PR TITLE
Add a public function that enables creation of the websocket codec

### DIFF
--- a/rpc/websocket_extensions_wasp.go
+++ b/rpc/websocket_extensions_wasp.go
@@ -1,0 +1,11 @@
+package rpc
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+func NewWebSocketCodec(conn *websocket.Conn, host string, req http.Header) ServerCodec {
+	return newWebsocketCodec(conn, host, req)
+}


### PR DESCRIPTION
This function is required to configure the evm websockets from outside of the library.